### PR TITLE
add batching to SolrJsonWriter

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'httpclient'
+require 'thread' # for Queue
 
 # Writes to a Solr using Solr's JSON update handler:
 # https://wiki.apache.org/solr/UpdateJSON
@@ -11,25 +12,34 @@ require 'httpclient'
 # ## Settings Used
 #
 # * solr.url: Path to your solr server
+# * "solr.update_batch_size" 
 # * solr_writer.commit_on_close : true or "true" means send a commit to Solr
 #   on close. We definitely encourage configuring Solr for auto commit too
 # * solr_writer.commit_on_close_timeout: in Seconds, how long to be willing to wait
 #   for Solr. 
+#
+# TODO: Quit fatally after more than X individual doc add errors, so we don't go on
+# for hours when it ain't working. Requires a thread-safe variable, make our own
+# with a mutex, or use one from concurrent-ruby if we add that. 
 class Traject::SolrJsonWriter
-  attr_reader :http_client
+  DefaultBatchSize = 200
+
+  attr_reader :http_client, :batch_queue
   attr_reader :settings
 
   def initialize(argSettings)
     @settings = argSettings
+    @settings["solr.update_batch_size"] ||= DefaultBatchSize
 
     # A HTTPClient will re-use persistent HTTP connections, in a thread-safe
     # way -- our HTTPClient object can be safely used by multiple threads simultaneously. 
-    #
-    # Note HTTPClient does have an async feature, which MIGHT be one option for
-    # improving performance in the future. 
     @http_client = HTTPClient.new
 
-    logger.info("   #{self.class.name} writing to `#{settings['solr.url']}`")
+    @batch_queue = Queue.new
+
+    @debug_ascii_progress = (@settings["debug_ascii_progress"].to_s == "true")
+
+    logger.info("   #{self.class.name} writing to `#{settings['solr.url']}` with batch size #{batch_size}")
     logger.info("   WARNING: #{self.class.name} is a LOW PERFORMANCE writer. For production use, traject recommends Jruby with SolrJWriter")
   end
 
@@ -39,31 +49,94 @@ class Traject::SolrJsonWriter
   # individual HTTP request to Solr. We do re-use HTTP connections which should
   # provide some performance advantage. 
   def put(context)
-    # Hash in an array.
-    json_package = JSON.generate( [ update_hash_for_context(context) ]  )
+    if batch_size <= 1
+      send_single_context_to_solr(context)
+    else
+      batch_queue << context
 
-    begin
-      response = http_client.post solr_update_url, json_package, "Content-type" => "application/json" 
-    rescue StandardError => exception
+      queue_size = batch_queue.size()
+      if queue_size >= batch_size
+        $stderr.write("^") if @debug_ascii_progress
+        send_batch_to_solr pull_from_queue(batch_queue, queue_size)
+      end
     end
+  end  
 
-    if exception || response.status != 200
+
+  # Takes an array of contexts, sends them to solr. If there's an error,
+  # prints out a warning and retries each individually with
+  # send_single_context_to_solr (the latter will write an error on each
+  # failed record if any continue to fail)
+  def send_batch_to_solr(context_array)
+    response, exception = send_to_solr(context_array)
+
+    $stderr.write("%") if @debug_ascii_progress
+
+    if exception || response.status != 200 
+      message = "Error encountered in batch solr add, will re-try documents individually, at a performance penalty...\n"
+      message += " Solr HTTP response #{response.status} #{response.body}" if response
+      message += Traject::Util.exception_to_log_message(e) if exception
+      message += "\n"
+      logger.warn message
+
+      context_array.each do |context|
+        send_single_context_to_solr context
+      end
+    end
+  end
+
+  # Takes a single Traject::Indexer::Context, 
+  # will output error logging on failure to save. 
+  #
+  # returns true or false, true means success. 
+  def send_single_context_to_solr(context)
+    response, exception = send_to_solr([context])
+
+    if exception || response.status != 200       
       id            = context.source_record && context.source_record['001'] && context.source_record['001'].value
       position      = context.position
       position_str  = position ? "at file position #{position} (starting at 1)" : ""
 
       message = "Could not index record #{id} #{position_str}."
       message += " Solr HTTP response #{response.status} #{response.body}" if response
-      message += " #{exception.class} #{exception.message}." if exception
-      message += "\n"
+      message += Traject::Util.exception_to_log_message(e) if exception
+      message += ".\n"
 
       logger.error(message)
       logger.debug(context.source_record.to_s)
+
+      return false
     end
+
+    return true
+  end
+
+  # Takes an array of Traject::Indexer::Context objects, sends them
+  # all to Solr. 
+  #
+  # returns an [http_response, exception] pair, where either may
+  # be nil in some error cases. Check excpeption non-nil or 
+  # http_response.status != 200 for error. 
+  def send_to_solr(array_of_contexts)
+    json_package = JSON.generate(  array_of_contexts.collect {|c| update_hash_for_context(c)} )
+
+    begin
+      response = http_client.post solr_update_url, json_package, "Content-type" => "application/json" 
+    rescue StandardError => exception
+    end
+
+    return [response, exception]
   end
 
   # Sends a commit if so configured.
   def close
+    # Any leftovers in batch buffer? Send em to the threadpool too.
+    if batch_queue.size > 0
+      $stderr.write("^") if @debug_ascii_progress
+
+      send_batch_to_solr pull_from_queue(batch_queue)      
+    end
+
     if settings["solr_writer.commit_on_close"].to_s == "true"
       commit_url = settings["solr.url"].chomp("/") + "/update?commit=true"
       logger.info "SolrJsonWriter: Sending commit at GET #{commit_url}" 
@@ -83,6 +156,23 @@ class Traject::SolrJsonWriter
 
   def logger
     settings["logger"] ||=  Yell.new(STDERR, :level => "gt.fatal") # null logger
+  end
+
+  def batch_size
+    @batch_size ||= settings["solr.update_batch_size"].to_i
+  end
+
+  def pull_from_queue(queue, number = nil)
+    number ||= queue.size
+
+    result = []
+
+    number.times do 
+      break if queue.empty?
+      result << queue.deq
+    end
+
+    return result
   end
 
 


### PR DESCRIPTION
I am not too interested in MRI performance compared to JRuby -- because of the GIL, you are never going to get JRuby-levels of total throughput on MRI. 

I am instead interested in if we get get SolrJsonWriter to be as performant as SolrJWriter on JRuby -- then it could be the default on both MRI and JRuby, and we could even get rid of the solrj.jar dependency which would be nice. 

So I added batching to SolrJsonWriter. I used stdlib ruby Queue so it would run on MRI too. 

It is hard to tell how much it helped, because I get SUCH varying results when running on against a real Solr. I think maybe it improved things, but still not to SolrJ levels.  But I'm not entirely sure it improved performance at all. 

@billdueber , if you wanted to do any, even messy, perf comparison of SolrJWriter vs SolrJsonWriter on Jruby, it would be helpful to see if you get what i was getting. 