### PR TITLE
Added delimited_writer (for tab-delimited files) and csv writer 

### DIFF
--- a/lib/traject/csv_writer.rb
+++ b/lib/traject/csv_writer.rb
@@ -1,0 +1,34 @@
+require 'traject/delimited_writer'
+require 'csv'
+
+# A CSV-writer, for folks who like that sort of thing.
+# Use DelimitedWriter for non-CSV lines (e.g., tab-delimited)
+#
+#
+
+class Traject::CSVWriter < Traject::DelimitedWriter
+
+  def initialize(*args)
+    super
+    self.delimiter = nil # Let CSV take care of it
+  end
+
+  def _write(data)
+    @output_file << data
+  end
+
+  # Turn the output file into a CSV writer
+  def open_output_file
+    of = super
+    CSV.new(of)
+  end
+
+  # Let CSV take care of the comma escaping
+  def escape(x)
+    x = x.to_s
+    x.gsub! internal_delimiter, @eidelim
+    x
+  end
+
+
+end

--- a/lib/traject/delimited_writer.rb
+++ b/lib/traject/delimited_writer.rb
@@ -1,0 +1,110 @@
+require 'traject/line_writer'
+
+# A simple line writer that uses configuration to determine
+# how to produce a tab-delimited file
+#
+# Appropos settings:
+#
+# * output_file  -- the file to write to
+# * output_stream -- the stream to write to, if defined and output_file is not
+# * delimited_writer.delimiter  -- What to separate fields with; default is tab
+# * delimited_writer.internal_delimiter -- Delimiter _within_ a field, for multiple
+#   values. Default is pipe ( | )
+# * delimited_writer.fields -- comma-separated list of the fields to output
+# * delimited_writer.header (true/false) -- boolean that determines if we should output a header row. Default is true
+# * delimited_writer.escape -- If a value actually contains the delimited or internal_delimiter, what to do?
+#   If unset, will follow the procedure below. If set, will turn it into the character(s) given
+#
+#
+# If `delimited_writer.escape` is not set, the writer will automatically
+# escape delimiters/internal_delimiters in the following way:
+#  * If the delimiter is a tab, replace tabs in values with a single space
+#  * If the delimiter is anything else, prefix it with a backslash
+
+class Traject::DelimitedWriter < Traject::LineWriter
+
+  attr_reader :delimiter,  :internal_delimiter, :edelim, :eidelim
+  attr_accessor :header
+
+  def initialize(settings)
+    super
+
+    # fields to output
+
+    begin
+      @fields = settings['delimited_writer.fields'].split(",")
+    rescue NoMethodError => e
+    end
+
+    if e or @fields.empty?
+      raise ArgumentError.new("#{self.class.name} must have a comma-delimited list of field names to output set in setting 'delimited_writer.fields'")
+    end
+
+    self.delimiter = settings['delimited_writer.delimiter'] || "\t"
+    self.internal_delimiter = settings['delimited_writer.internal_delimiter'] || '|'
+    self.header = settings['delimited_writer.header'].to_s != 'false'
+
+    # Output the header if need be
+    write_header if @header
+  end
+
+  def escaped_delimiter(d)
+    return nil if d.nil?
+    d == "\t" ? ' ' : '\\' + d
+  end
+
+  def delimiter=(d)
+    @delimiter = d
+    @edelim = escaped_delimiter(d)
+    self
+  end
+
+  def internal_delimiter=(d)
+    @internal_delimiter = d
+    @eidelim =  escaped_delimiter(d)
+  end
+
+
+
+
+  def write_header
+    _write(@fields)
+  end
+
+  def _write(data)
+    output_file.puts(data.join(delimiter))
+  end
+
+  # Get the output values out of the context
+  def raw_output_values(context)
+    context.output_hash.values_at(*@fields)
+  end
+
+  # Escape the delimiters in whatever way has been defined
+  def escape(x)
+    x = x.to_s
+    x.gsub! @delimiter, @edelim if @delimiter
+    x.gsub! @internal_delimiter, @eidelim
+    x
+  end
+
+
+  # Derive actual output field values from the raw values
+  def output_values(raw)
+    raw.map do |x|
+      if x.is_a? Array
+        x.map!{|s| escape(s)}
+        x.join(@internal_delimiter)
+      else
+        escape(x)
+      end
+    end
+  end
+
+  # Spit out the escaped values joined by the delimiter
+  def serialize(context)
+    output_values(raw_output_values(context))
+  end
+
+
+end

--- a/test/delimited_writer_test.rb
+++ b/test/delimited_writer_test.rb
@@ -1,0 +1,81 @@
+# Encoding: UTF-8
+
+require 'test_helper'
+require 'stringio'
+require 'traject/delimited_writer'
+require 'traject/csv_writer'
+
+describe "Delimited/CSV Writers" do
+
+  before do
+    @out                 = StringIO.new
+    @settings            = {'output_stream' => @out, 'delimited_writer.fields' => 'four,one,two'}
+    @context             = Struct.new(:output_hash).new
+    @context.output_hash = {'one' => 'one', 'two' => %w[two1 two2], 'three' => 'three', 'four' => 'four'}
+  end
+
+  after do
+    @out.close
+  end
+
+  describe "Traject::DelimitedWriter" do
+
+    it "creates a dw with defaults" do
+      dw = Traject::DelimitedWriter.new(@settings)
+      dw.delimiter.must_equal "\t"
+      dw.internal_delimiter.must_equal '|'
+      dw.edelim.must_equal ' '
+      dw.eidelim.must_equal '\\|'
+    end
+
+    it "respects different delimiter" do
+      @settings['delimited_writer.delimiter'] = '^'
+      dw                                      = Traject::DelimitedWriter.new(@settings)
+      dw.delimiter.must_equal '^'
+      dw.edelim.must_equal '\\^'
+      dw.internal_delimiter.must_equal '|'
+    end
+
+    it "outputs a header if asked to" do
+      dw = Traject::DelimitedWriter.new(@settings)
+      @out.string.chomp.must_equal %w[four one two].join("\t")
+    end
+
+    it "doesn't output a header if asked not to" do
+      @settings['delimited_writer.header'] = 'false'
+      dw                                   = Traject::DelimitedWriter.new(@settings)
+      @out.string.must_be_empty
+    end
+
+    it "deals with multiple values" do
+      dw = Traject::DelimitedWriter.new(@settings)
+      dw.put @context
+      @out.string.split("\n").last.must_equal ['four', 'one', 'two1|two2'].join(dw.delimiter)
+    end
+
+    it "bails if delimited_writer.fields isn't set" do
+      @settings.delete 'delimited_writer.fields'
+      proc { Traject::DelimitedWriter.new(@settings) }.must_raise(ArgumentError)
+    end
+
+  end
+
+  describe "Traject::CSVWriter" do
+    it "unsets the delimiter" do
+      cw = Traject::CSVWriter.new(@settings)
+      cw.delimiter.must_be_nil
+    end
+
+    it "writes the header" do
+      cw = Traject::CSVWriter.new(@settings)
+      @out.string.chomp.must_equal 'four,one,two'
+    end
+
+    it "uses the internal delimiter" do
+      cw = Traject::CSVWriter.new(@settings)
+      cw.put @context
+      @out.string.split("\n").last.must_equal ['four', 'one', 'two1|two2'].join(',')
+    end
+
+  end
+end

--- a/test/delimited_writer_test.rb
+++ b/test/delimited_writer_test.rb
@@ -5,6 +5,8 @@ require 'stringio'
 require 'traject/delimited_writer'
 require 'traject/csv_writer'
 
+require 'csv'
+
 describe "Delimited/CSV Writers" do
 
   before do
@@ -75,6 +77,27 @@ describe "Delimited/CSV Writers" do
       cw = Traject::CSVWriter.new(@settings)
       cw.put @context
       @out.string.split("\n").last.must_equal ['four', 'one', 'two1|two2'].join(',')
+    end
+
+    it "produces complex output" do
+      @context.output_hash = {
+          'four' => ['Bill Clinton, Jr.', 'Jesse "the Body" Ventura'],
+          'one' => 'Willard "Mitt" Romney',
+          'two' => 'Dueber, Bill'
+      }
+      canonical = StringIO.new
+      csv = CSV.new(canonical)
+
+      csv_vals = [@context.output_hash['four'].join('|'), @context.output_hash['one'], @context.output_hash['two']]
+      csv << csv_vals
+      csv_output = canonical.string.chomp
+
+      cw = Traject::CSVWriter.new(@settings)
+      cw.put @context
+      traject_csvwriter_output = @out.string.split("\n").last.chomp
+
+      assert_equal(csv_output, traject_csvwriter_output)
+
     end
 
   end


### PR DESCRIPTION
[Submitted as a pull request because it's not at all clear to me that we want to include these in the main traject gem -- they could easily be pulled out into a gem of their own, like so many other pieces of the traject infrastructure. Thoughts?]

Two new writers, with a little cleanup of `traject/line_writer.rb`

* DelimitedWriter will write delimited records, one per line, with defaults
  that produce tab-delimited rows with pipes for intra-field delineation.
* CSVWriter wraps it up in the stock CSV library

Both require at least one setting: `delimited_writer.fields` is a
comma-delimited list of the field names to be output, in the order you
want them written.

Added both writers and some simple tests. Still needs mention in the standalone docs if we decide to integrate this into traject proper.
