### PR TITLE
default processing_thread_pool based on

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -63,13 +63,16 @@ settings are applied first of all. It's recommended you use `provide`.
                  or Writer classes that write to files, like Traject::JsonWriter. Has an shortcut
                  `-o` on command line. 
 
-* `processing_thread_pool` Default 3. Main thread pool used for processing records with input rules. Choose a
-   pool size based on size of your machine, and complexity of your indexing rules. 
-   Probably no reason for it ever to be more than number of cores on indexing machine.  
-   But this is the first thread_pool to try increasing for better performance on a multi-core machine. 
+* `processing_thread_pool` Number of threads in the main thread pool used for processing 
+   records with input rules. On JRuby or Rubinius, defaults to 1 less than the number of processors detected on your machine. On other ruby platforms, defaults to 1. Set to 0 or nil
+   to disable thread pool, and do all processing in main thread. 
+
+   Choose a pool size based on size of your machine, and complexity of your indexing rules, you
+   might want to try different sizes and measure which works best for you.
+   Probably no reason for it ever to be more than number of cores on indexing machine.
    
-   A pool here can sometimes result in multi-threaded commiting to Solr too with the
-   SolrJWriter, as processing worker threads will do their own commits to solr if the
+   A value greater than 1 here can sometimes still result in multi-threaded commiting to Solr, as
+   processing worker threads will do their own commits to solr if the
    solrj_writer.thread_pool is full. Having a multi-threaded pool here can help even out throughput
    through Solr's pauses for committing too. 
 

--- a/lib/traject/indexer/settings.rb
+++ b/lib/traject/indexer/settings.rb
@@ -1,4 +1,5 @@
 require 'hashie'
+require 'concurrent'
 
 class Traject::Indexer
 
@@ -64,7 +65,7 @@ class Traject::Indexer
       "marc_source.type"          => "binary",            
       "solrj_writer.batch_size"   => 200,
       "solrj_writer.thread_pool"  => 1,
-      "processing_thread_pool"    => 3,
+      "processing_thread_pool"    => self.default_processing_thread_pool,
       "log.batch_size.severity"   => "info"
       }
     end
@@ -76,5 +77,15 @@ class Traject::Indexer
         hash
       end.inspect
     end
+
+    protected
+    def self.default_processing_thread_pool
+      if ["jruby", "rbx"].include? ENV["RUBY_ENGINE"]
+        [1, Concurrent.processor_count - 1].max
+      else
+        1
+      end
+    end
+
   end
 end


### PR DESCRIPTION
...platform and number of detected processors. On non-GIL
interpreters, default to 1 less than number of processors.
(Should be equal to number of processors instead?)

On MRI, default to 1. I think 1 is better than 0 here, so
if the 'main' thread the Reader is running in is blocked
on I/O, the mapping in it's own 1 thread can still be switched
in to do work. But if someone wants to do some actual tests
in MRI, we could determine for sure if 0 or 1 is best, this is
just my best guess.