### PR TITLE
Remove any refs to jruby-only from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Initially by Jonathan Rochkind (Johns Hopkins Libraries) and Bill Dueber (Univer
 
 Traject was born out of our experience with similar tools, including the very popular and useful [solrmarc](https://code.google.com/p/solrmarc/) by Bob Haschart; and Bill Dueber's own [marc2solr](http://github.com/billdueber/marc2solr/).
 
-We're comfortable programming (especially in a dynamic language), and want to be able to experiment with different indexing patterns quickly, easily, and testably; but are admittedly less comfortable in Java.  In order to have a tool with the API's and usage patterns convenient for us, we found we could do it better in JRuby -- Ruby on the JVM.
+We're comfortable programming (especially in a dynamic language), and want to be able to experiment with different indexing patterns quickly, easily, and testably; but are admittedly less comfortable in Java.  In order to have a tool with the API's and usage patterns convenient for us, we found we could do it better in ruby.
 
 * Basic configuration files can be easily written even by non-rubyists,  with a few simple directives traject provides. But config files are 'ruby all the way down', so we can provide a gradual slope to more complex needs, with the full power of ruby.
 * Easy to program, easy to read, easy to modify.
@@ -36,7 +36,7 @@ that can combine to deal with any of your local needs.
 
 ## Installation
 
-Traject runs under MRI ruby (1.9 or 2.2) and jruby 1.7.x (ruby on the JVM). We recommend [chruby](https://github.com/postmodern/chruby) and [ruby-install](https://github.com/postmodern/ruby-install#readme) for installing and managing ruby installations.
+Traject runs under MRI ruby (1.9 or 2.2) and jruby >= 1.7.x (ruby on the JVM). We recommend [chruby](https://github.com/postmodern/chruby) and [ruby-install](https://github.com/postmodern/ruby-install#readme) for installing and managing ruby installations.
 
 Then just `gem install traject`.
 

--- a/doc/batch_execution.md
+++ b/doc/batch_execution.md
@@ -8,17 +8,17 @@ with suggested solutions, and additional hints.
 
 ## Ruby version setting
 
-traject ordinarily needs to run under jruby. You will
+traject can run under any ruby, but will be best able to take advantage
+of multiple threads under jruby. You will
 ordinarily have jruby installed under a ruby version switcher -- we
 highly recommend [chruby](https://github.com/postmodern/chruby) over other choices,
 but other popular choices include rvm and rbenv.
 
-Remember that traject needs to run in 1.9.x mode in jruby--
-with jruby 1.7.x or later, this should be default, recommend
-you use jruby 1.7.x.
+**JRuby users**: Remember that traject needs to run in 1.9.x or 2.x mode in jruby--
+with jruby 1.7.x or later, this should be default.
 
 Especially when running under a cron job, it can be difficult to
-set things up so traject runs under jruby -- and then when you add
+set things up so traject runs under a specific ruby implementation -- and then when you add
 bundler into it, things can get positively byzantine. It's not you,
 this gets confusing. 
 


### PR DESCRIPTION
Just a quick check to make sure we're not asserting that traject will only work under JRuby.