### PR TITLE
Rename traject_marc4j_reader to traject-marc4j_reader 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ settings do
   # The default reader is Traject::MarcReader, which uses the
   # normal ruby-marc gem. A MARC reader based on the java
   # marc4j library is available but no longer packaged with traject; see
-  # https://github.com/billdueber/traject_marc4j_reader if
+  # https://github.com/traject-project/traject-marc4j_reader if
   # you want to use it. It generally gives a performance boost when reading
   # both marc21 binary and marc-xml files.
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -74,7 +74,7 @@ settings are applied first of all. It's recommended you use `provide`.
    through Solr's pauses for committing too.
 
 * `reader_class_name`: a Traject Reader class, used by the indexer as a source of records. Default Traject::MarcReader, the pure
-ruby reader. When running under JRuby, the Traject::Marc4JReader (available in the traject_marc4j_reader gem) will sometimes, but not always,
+ruby reader. When running under JRuby, the Traject::Marc4JReader (available in the traject-marc4j_reader gem) will sometimes, but not always,
 give better performance. Command-line shortcut `-r`
 
 * `solr.url`: URL to connect to a solr instance for indexing, eg http://example.org:8983/solr . Command-line short-cut `-u`.

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -54,7 +54,7 @@ require 'traject/macros/basic'
 #
 #  The default reader is the Traject::MarcReader, who's behavior is
 #  further customized by several settings in the Settings hash. Jruby users
-#  with specialized needs may want to look at the gem traject_marc4j_reader.
+#  with specialized needs may want to look at the gem traject-marc4j_reader.
 #
 #  Alternate readers can be set directly with the #reader_class= method, or
 #  with the "reader_class_name" Setting, a String name of a class

--- a/lib/traject/marc_reader.rb
+++ b/lib/traject/marc_reader.rb
@@ -6,7 +6,7 @@ require 'traject/ndj_reader'
 #
 # Marc4JReader is an alternative to this class, powered by Marc4J. You may be interested
 # in comparing for performance, under your particular use case. To use it, you'll need
-# the gem traject_marc4j_reader.
+# the gem traject-marc4j_reader.
 #
 # By default assumes binary MARC encoding, please set marc_source.type setting
 # for XML or json. If binary, please set marc_source.encoding with char encoding. 


### PR DESCRIPTION
to conform to bundler naming conventions and put under the traject-project organization.