### PR TITLE
Generate platform-specific gems from a single traject.gemspec

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -12,6 +12,11 @@ require 'traject/solr_json_writer'
 require 'traject/macros/marc21'
 require 'traject/macros/basic'
 
+if defined? JRUBY_VERSION
+  require 'traject/solrj_writer'
+  require 'traject/marc4j_reader'
+end
+
 # This class does indexing for traject: Getting input records from a Reader
 # class, mapping the input records to an output hash, and then sending the output
 # hash off somewhere (usually Solr) with a Writer class.

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -13,7 +13,6 @@ require 'traject/macros/marc21'
 require 'traject/macros/basic'
 
 if defined? JRUBY_VERSION
-  require 'traject/solrj_writer'
   require 'traject/marc4j_reader'
 end
 

--- a/lib/traject/indexer/settings.rb
+++ b/lib/traject/indexer/settings.rb
@@ -57,10 +57,18 @@ class Traject::Indexer
     def fill_in_defaults!
       self.reverse_merge!(self.class.defaults)
     end
-
+    
+    def self.default_reader
+      if defined? JRUBY_VERSION
+        "Traject::Marc4JReader"
+      else 
+        "Traject::MarcReader"
+      end
+    end
+    
     def self.defaults
       @@defaults ||= {
-      "reader_class_name"         => "Traject::MarcReader",
+      "reader_class_name"         => self.default_reader,
       "writer_class_name"         => "Traject::SolrJsonWriter",
       "marc_source.type"          => "binary",            
       "solrj_writer.batch_size"   => 200,

--- a/lib/traject/indexer/settings.rb
+++ b/lib/traject/indexer/settings.rb
@@ -58,24 +58,35 @@ class Traject::Indexer
       self.reverse_merge!(self.class.defaults)
     end
     
-    def self.default_reader
-      if defined? JRUBY_VERSION
-        "Traject::Marc4JReader"
-      else 
-        "Traject::MarcReader"
-      end
+    
+    def self.mri_defaults
+      {
+        "reader_class_name"         => "Traject::MarcReader",
+        "writer_class_name"         => "Traject::SolrJsonWriter",
+        "marc_source.type"          => "binary",            
+        "solrj_writer.batch_size"   => 200,
+        "solrj_writer.thread_pool"  => 1,
+        "processing_thread_pool"    => self.default_processing_thread_pool,
+        "log.batch_size.severity"   => "info"
+      }
+    end
+
+    def self.jruby_defaults
+      {
+        'reader_class_name' => "Traject::Marc4JReader",
+        'marc4j_reader.permissive' => true
+      }
     end
     
+        
     def self.defaults
-      @@defaults ||= {
-      "reader_class_name"         => self.default_reader,
-      "writer_class_name"         => "Traject::SolrJsonWriter",
-      "marc_source.type"          => "binary",            
-      "solrj_writer.batch_size"   => 200,
-      "solrj_writer.thread_pool"  => 1,
-      "processing_thread_pool"    => self.default_processing_thread_pool,
-      "log.batch_size.severity"   => "info"
-      }
+      return @@defaults if defined? @@defaults
+      default_settings = self.mri_defaults
+      if defined? JRUBY_VERSION
+        default_settings.merge! self.jruby_defaults
+      end
+      
+      @@defaults = default_settings
     end
 
     def inspect

--- a/test/indexer/settings_test.rb
+++ b/test/indexer/settings_test.rb
@@ -124,5 +124,29 @@ describe "Traject::Indexer#settings" do
       assert_equal( {"a" => "a", "password" => "[hidden]", "some_password" => "[hidden]", "some.password" => "[hidden]"}, parsed)
     end
   end
+  
+  describe "JRuby / MRI" do
+    before do
+      @indexer = Traject::Indexer.new
+    end
+    
+    it "has the right indexer name" do
+      if defined? JRUBY_VERSION
+        assert_equal "Traject::Marc4JReader", @indexer.settings['reader_class_name']
+      else
+        assert_equal "Traject::MarcReader", @indexer.settings['reader_class_name']
+      end
+    end
+    
+    # This next one has the added effect of making sure the correct class
+    # has actually been loaded -- otherwise the constant wouldn't be available
+    it "has the correct default indexer class based on platform" do
+      if defined? JRUBY_VERSION
+        assert_equal Traject::Marc4JReader, @indexer.reader_class
+      else
+        assert_equal Traject::MarcReader, @indexer.reader_class
+      end
+    end
+  end
 
 end

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -28,6 +28,18 @@ Gem::Specification.new do |spec|
   spec.add_dependency "yell"                        # logging
   spec.add_dependency "dot-properties", ">= 0.1.1"  # reading java style .properties
   spec.add_dependency "httpclient", "~> 2.5"
+  
+  # If we're building the package under JRuby, add in the 
+  # jruby-only gems and specify the platform.
+  
+  if defined? JRUBY_VERSION
+    spec.platform = 'java'
+    spec.add_dependency "traject-marc4j_reader", "~>1"
+    spec.add_dependency "traject-solrj_writer",  "~>1"
+  else
+    spec.platform = "ruby"
+  end
+  
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   if defined? JRUBY_VERSION
     spec.platform = 'java'
     spec.add_dependency "traject-marc4j_reader", "~>1"
-    spec.add_dependency "traject-solrj_writer",  "~>1"
   else
     spec.platform = "ruby"
   end


### PR DESCRIPTION
I looked at how Oga does it, and I think it's as easy as doing what I've done here. We just need to remember to release using both MRI and JRuby.

I ran `rake build` with both MRI and JRuby and untarred the resulting gemfiles (`traject-2.0.pre-java.gem` and `traject-2.0.pre.gem`) to look at them. The metadata  (e.g., list of dependencies) all looks good. I verified that `require "traject"` under jruby does, in fact, load up the marc4j and solrj stuff (required only under JRuby in `index.rb`). 

I _think_ all we need to do is decide what the defaults should be under JRuby, set them in a `if defined? JRUBY_VERSION` block and we're home free.