### PR TITLE
change Traject::Version to Traject::VERSION in command_line.rb

### DIFF
--- a/lib/traject/command_line.rb
+++ b/lib/traject/command_line.rb
@@ -55,7 +55,7 @@ module Traject
       # with logging config.
       #####
 
-      indexer.logger.info("traject (#{Traject::Version}) executing with: `#{orig_argv.join(' ')}`")
+      indexer.logger.info("traject (#{Traject::VERSION}) executing with: `#{orig_argv.join(' ')}`")
 
       # Okay, actual command process! All command_ methods should return true
       # on success, or false on failure.


### PR DESCRIPTION
Avoid this error:

FATAL Traject::CommandLine: Unexpected exception, terminating execution: #<NameError: uninitialized constant Traject::Version>
/home/eoghan/.rvm/gems/ruby-2.1.5/gems/traject-2.0.0/lib/traject/command_line.rb:58:in `execute': uninitialized constant Traject::Version (NameError)
