### PR TITLE
SolrJsonWriter, guard marc-specific in record_id_from_context fixes #92

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -167,9 +167,11 @@ class Traject::SolrJsonWriter
   end
 
   # Returns MARC 001, then a slash, then output_hash["id"] -- if both
-  # are present. Otherwise may return just one, or even an empty string. 
+  # are present. Otherwise may return just one, or even an empty string.
   def record_id_from_context(context)
-    marc_id = context.source_record && context.source_record['001'] && context.source_record['001'].value
+    marc_id = if context.source_record && context.source_record.kind_of?(MARC::Record)
+      context.source_record['001'].value
+    end
     output_id = context.output_hash["id"]
 
     return [marc_id, output_id].compact.join("/")

--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -169,7 +169,9 @@ class Traject::SolrJsonWriter
   # Returns MARC 001, then a slash, then output_hash["id"] -- if both
   # are present. Otherwise may return just one, or even an empty string.
   def record_id_from_context(context)
-    marc_id = if context.source_record && context.source_record.kind_of?(MARC::Record)
+    marc_id = if context.source_record &&
+                 context.source_record.kind_of?(MARC::Record) &&
+                 context.source_record['001']
       context.source_record['001'].value
     end
     output_id = context.output_hash["id"]


### PR DESCRIPTION
For now I think this is all we need for #92.  Although it really needs a test, since I'm not sure how to use Indexer with non-MARC at all at present, I'm not sure how to write one!

Long-term, I think the right design choice is capability to specify in configuration either a Traject::Indexer sub-class and/or one or more mix-in modules to the Traject::Indexer. The primary use case for that would be different source record types -- which would over-ride methods like `record_id_from_context` in source-type-specific ways but also likely add other macro methods (eg not including not `extract_marc` but including other source-type-specific useful macros -- I tried to name _all_ the marc-specific macros with "marc" in them for this reason.

Once we went down this path, there'd be a generic Indexer base class that did not have any marc specific stuff (including not mixing in the MARC-specific macros) -- but I'd still want the marc-specific one to be _default_ probably, but that could be debated at the time. 

I think it's too early for that now, before we have cowpaths to pave, and I think this very simple change should make it possible for erikhatcher to do the experimentation he wants? @erikhatcher? 